### PR TITLE
Python modules and ignore cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /websteps
 /websteps.exe
 __pycache__
+CACHE

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,3 @@
+tabulate >= 0.8.9
+yattag >= 1.14.0
+dnslib >= 0.9.19


### PR DESCRIPTION
Minor improvements to code base.
 
Always ignore the CACHE folder. 
Install the python modules before running python analysis scripts.  